### PR TITLE
Added working func_hlvr_nav_markup

### DIFF
--- a/gameinfo.gi
+++ b/gameinfo.gi
@@ -155,7 +155,7 @@
 		"DefaultSolidEntity"			"trigger_multiple"
 		"DefaultPointEntity"			"info_player_start"
 		"DefaultPathEntity"				"path_particle_rope"
-		"NavMarkupEntity"				"func_nav_markup"
+		"NavMarkupEntity"				"func_hlvr_nav_markup"
 		"OverlayBoxSize"				"8"
 		"UsesBakedLighting"				"1"
 		"TileMeshesEnabled"				"1"


### PR DESCRIPTION
Now that func_hlvr_nav_markup is working, we no longer need to change the NavMarkupEntity in gameinfo.gi for working navigation. This change reverts the NavMarkupEntity to the entity Valve intended.